### PR TITLE
Use default timeout

### DIFF
--- a/lib/command/sequencer.ex
+++ b/lib/command/sequencer.ex
@@ -39,6 +39,7 @@ defmodule FinTex.Command.Sequencer do
     timeout = nil
     || Keyword.get(options, :http_options, []) |> Keyword.get(:timeout)
     || Application.get_env(:fintex, :http_options, []) |> Keyword.get(:timeout)
+    || 10_000
 
     options = options
     |> Keyword.merge([ssl_options: ssl_options, ibrowse: ibrowse, timeout: timeout])


### PR DESCRIPTION
When no timeout is set in config/config.exs use a sane default timeout.
