### PR TITLE
Added :xml_builder to list of applications to fix compilation error

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,8 @@ defmodule FinTex.Mixfile do
         :ibrowse,
         :logger,
         :ssl_verify_hostname,
-        :timex
+        :timex,
+        :xml_builder
       ]
     ]
   end


### PR DESCRIPTION
Missing `:xml_builder` entry in application section causes the following error on compilation:

```
== Compilation error on file lib/segment/hkccs.ex ==
** (CompileError) lib/segment/hkccs.ex:15: module XmlBuilder is not loaded and could not be found

== Compilation error on file lib/command/initiate_payment.ex ==
** (CompileError) lib/command/initiate_payment.ex:72: FinTex.Segment.HKCCS.__struct__/0 is undefined, cannot expand struct FinTex.Segment.HKCCS
    (elixir) src/elixir_map.erl:58: :elixir_map.translate_struct/4
```
