### PR TITLE
Add support for HISPAS segment version 3

### DIFF
--- a/lib/segment/hispas.ex
+++ b/lib/segment/hispas.ex
@@ -42,6 +42,27 @@ defmodule FinTex.Segment.HISPAS do
         ]
     }
   end
+
+  def new(segment = [["HISPAS", _, 3, _] | _]) do
+    %__MODULE__{
+      segment:
+      [
+        segment |> Enum.at(0),
+        segment |> Enum.at(1),
+        segment |> Enum.at(2),
+        segment |> Enum.at(3),
+        [
+          segment |> Enum.at(4) |> Enum.at(0),
+          segment |> Enum.at(4) |> Enum.at(1),
+          segment |> Enum.at(4) |> Enum.at(2),
+          segment |> Enum.at(4) |> Enum.at(3),
+          segment |> Enum.at(4) |> Enum.at(4),
+
+          segment |> Enum.at(4) |> Enum.drop(5)
+        ]
+      ]
+    }
+  end
 end
 
 


### PR DESCRIPTION
Compared to version 2, version 3 has an additional field for the amount of
reserved characters in a reference ("Anzahl reservierter Verwendungsstellen").
