### PR TITLE
Prevent use of function reference in config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,7 +22,7 @@ config :fintex, :http_options,
 #   [
 #     verify: :verify_peer,
 #     cacertfile: Path.join(["/", "etc", "ssl", "certs", "ca-certificates.crt"]) |> to_char_list,
-#     verify_fun: {&:ssl_verify_hostname.verify_fun/3, []},
+#     verify_fun: {{:ssl_verify_hostname, :verify_fun, 3}, []},
 #     depth: 99
 #   ]
 

--- a/lib/connection/http_client.ex
+++ b/lib/connection/http_client.ex
@@ -34,16 +34,17 @@ defmodule FinTex.Connection.HTTPClient do
       _ ->
         %URI{host: host} = URI.parse(url)
         hostname = to_charlist(host)
-        {verify_fun, initial_user_state} = options[:ssl_options][:verify_fun]
+        {{module, function, arity}, initial_user_state} = options[:ssl_options][:verify_fun]
+        verify_fun = :erlang.make_fun(module, function, arity)
         Keyword.merge(
+          options[:ssl_options],
           [
             verify_fun: {
               verify_fun,
               List.keyreplace(initial_user_state, :check_hostname, 0, {:check_hostname, hostname})
             },
             server_name_indication: hostname
-          ],
-          options[:ssl_options]
+          ]
         )
     end
 


### PR DESCRIPTION
Distiller does not play nicely with such references [1]. Thus, I use
`:erlang.make_fun` for turning the `{module, function, arity}` tuple
into a function. Since `Keyword.merge` would have overridden the
function by the tuple again, the argument order had to be switched.

[1]: https://github.com/bitwalker/exrm/issues/230